### PR TITLE
Add SwiftUI Wake-on-LAN app with Siri shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # Wake-on-line
+
+Application iOS permettant de démarrer des ordinateurs à distance via Wake-on-LAN.
+
+Fonctionnalités principales :
+
+- Gestion d'une liste d'ordinateurs avec nom, adresse MAC et adresse IP locale.
+- Envoi de paquets magic WOL sur le port UDP 9.
+- Sauvegarde locale des machines via `UserDefaults`.
+- Intégration Siri via `AppIntents` pour dire : *"Allume [nom de l'ordinateur]"*.
+
+Le projet est entièrement réalisé en SwiftUI et ne dépend d'aucune bibliothèque tierce.

--- a/WakeOnLine/Intents/WakeComputerIntent.swift
+++ b/WakeOnLine/Intents/WakeComputerIntent.swift
@@ -1,0 +1,63 @@
+import AppIntents
+import Foundation
+
+struct ComputerEntity: AppEntity {
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Ordinateur")
+    var id: UUID
+    var name: String
+    var macAddress: String
+    var ipAddress: String
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: name)
+    }
+
+    static var defaultQuery = ComputerQuery()
+}
+
+struct ComputerQuery: EntityQuery {
+    func entities(for identifiers: [UUID]) async throws -> [ComputerEntity] {
+        let comps = ComputerStore.shared.computers.filter { identifiers.contains($0.id) }
+        return comps.map { $0.toEntity() }
+    }
+
+    func suggestedEntities() async throws -> [ComputerEntity] {
+        ComputerStore.shared.computers.map { $0.toEntity() }
+    }
+}
+
+extension Computer {
+    func toEntity() -> ComputerEntity {
+        ComputerEntity(id: id, name: name, macAddress: macAddress, ipAddress: ipAddress)
+    }
+}
+
+struct WakeComputerIntent: AppIntent {
+    static var title: LocalizedStringResource = "Allume un ordinateur"
+
+    @Parameter(title: "Ordinateur")
+    var computer: ComputerEntity
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Allume \(\.$computer)")
+    }
+
+    func perform() async throws -> some IntentResult {
+        let store = ComputerStore.shared
+        if let comp = store.computers.first(where: { $0.id == computer.id }) {
+            store.wake(comp)
+        }
+        return .result()
+    }
+}
+
+struct WakeShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        [
+            AppShortcut(intent: WakeComputerIntent(), phrases: [
+                "Allume \\(.applicationName) \\(.computer)",
+                "Allume \\(.computer)"
+            ])
+        ]
+    }
+}

--- a/WakeOnLine/Models/Computer.swift
+++ b/WakeOnLine/Models/Computer.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct Computer: Identifiable, Codable, Hashable {
+    var id: UUID
+    var name: String
+    var macAddress: String
+    var ipAddress: String
+
+    init(id: UUID = UUID(), name: String, macAddress: String, ipAddress: String) {
+        self.id = id
+        self.name = name
+        self.macAddress = macAddress
+        self.ipAddress = ipAddress
+    }
+}

--- a/WakeOnLine/Models/ComputerStore.swift
+++ b/WakeOnLine/Models/ComputerStore.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Combine
+
+final class ComputerStore: ObservableObject {
+    static let shared = ComputerStore()
+
+    @Published var computers: [Computer] = [] {
+        didSet { save() }
+    }
+
+    private let defaults: UserDefaults
+    private let key = "computers"
+
+    private init() {
+        defaults = UserDefaults(suiteName: "group.wakeonline") ?? .standard
+        load()
+    }
+
+    private func load() {
+        guard let data = defaults.data(forKey: key) else { return }
+        do {
+            computers = try JSONDecoder().decode([Computer].self, from: data)
+        } catch {
+            print("Failed to decode computers: \(error)")
+        }
+    }
+
+    private func save() {
+        do {
+            let data = try JSONEncoder().encode(computers)
+            defaults.set(data, forKey: key)
+        } catch {
+            print("Failed to encode computers: \(error)")
+        }
+    }
+
+    func add(_ computer: Computer) {
+        computers.append(computer)
+    }
+
+    func update(_ computer: Computer) {
+        if let idx = computers.firstIndex(where: { $0.id == computer.id }) {
+            computers[idx] = computer
+        }
+    }
+
+    func remove(at offsets: IndexSet) {
+        computers.remove(atOffsets: offsets)
+    }
+
+    func wake(_ computer: Computer) {
+        WakeOnLAN.send(mac: computer.macAddress, ip: computer.ipAddress)
+    }
+}

--- a/WakeOnLine/Networking/WakeOnLAN.swift
+++ b/WakeOnLine/Networking/WakeOnLAN.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Network
+
+enum WakeOnLAN {
+    static func send(mac: String, ip: String, port: UInt16 = 9) {
+        guard let macBytes = parse(mac: mac) else { return }
+        var packet = Data(repeating: 0xFF, count: 6)
+        for _ in 0..<16 {
+            packet.append(contentsOf: macBytes)
+        }
+        let host = NWEndpoint.Host(ip)
+        let port = NWEndpoint.Port(rawValue: port)!
+        let connection = NWConnection(host: host, port: port, using: .udp)
+        connection.stateUpdateHandler = { state in
+            if case .ready = state {
+                connection.send(content: packet, completion: .contentProcessed { _ in
+                    connection.cancel()
+                })
+            }
+        }
+        connection.start(queue: .global())
+    }
+
+    private static func parse(mac: String) -> [UInt8]? {
+        let parts = mac.split(separator: ":")
+        guard parts.count == 6 else { return nil }
+        return parts.compactMap { UInt8($0, radix: 16) }
+    }
+}

--- a/WakeOnLine/Views/AddEditComputerView.swift
+++ b/WakeOnLine/Views/AddEditComputerView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct AddEditComputerView: View {
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var store = ComputerStore.shared
+
+    @State private var name: String = ""
+    @State private var macAddress: String = ""
+    @State private var ipAddress: String = ""
+
+    var computer: Computer?
+
+    init(computer: Computer? = nil) {
+        self.computer = computer
+        _name = State(initialValue: computer?.name ?? "")
+        _macAddress = State(initialValue: computer?.macAddress ?? "")
+        _ipAddress = State(initialValue: computer?.ipAddress ?? "")
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Nom", text: $name)
+                TextField("Adresse MAC", text: $macAddress)
+                TextField("Adresse IP", text: $ipAddress)
+                    .keyboardType(.numbersAndPunctuation)
+            }
+            .navigationTitle(computer == nil ? "Ajouter" : "Modifier")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Annuler") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Enregistrer") {
+                        let comp = Computer(id: computer?.id ?? UUID(), name: name, macAddress: macAddress, ipAddress: ipAddress)
+                        if computer == nil {
+                            store.add(comp)
+                        } else {
+                            store.update(comp)
+                        }
+                        dismiss()
+                    }
+                    .disabled(name.isEmpty || macAddress.isEmpty || ipAddress.isEmpty)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    AddEditComputerView()
+}

--- a/WakeOnLine/Views/ContentView.swift
+++ b/WakeOnLine/Views/ContentView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var store = ComputerStore.shared
+    @State private var showingAdd = false
+    @State private var editingComputer: Computer?
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(store.computers) { computer in
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(computer.name).font(.headline)
+                            Text(computer.macAddress).font(.caption)
+                            Text(computer.ipAddress).font(.caption)
+                        }
+                        Spacer()
+                        Button("Allumer") {
+                            store.wake(computer)
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        editingComputer = computer
+                    }
+                }
+                .onDelete(perform: store.remove)
+            }
+            .navigationTitle("Ordinateurs")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    EditButton()
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showingAdd = true }) {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingAdd) {
+                AddEditComputerView()
+            }
+            .sheet(item: $editingComputer) { comp in
+                AddEditComputerView(computer: comp)
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/WakeOnLine/WakeOnLineApp.swift
+++ b/WakeOnLine/WakeOnLineApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct WakeOnLineApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- build SwiftUI iOS app to list computers and send Wake-on-LAN packets
- store computers in UserDefaults and allow add/edit/remove
- integrate AppIntents for Siri phrase "Allume [nom]"

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688f096fad68832cb43104d4ef8b1172